### PR TITLE
Issue 27 🚸 Unblock domains for Certificate validation for Apple devices

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -581,7 +581,6 @@ news.apple.com
 np.itunes.apple.com
 ns.itunes.apple.com
 ns.itunes-apple.com.akadns.net
-ocsp.apple.com
 ocsp.godaddy.com.akadns.net
 opensource.apple.com
 origin.guzzoni-apple.com.akadns.net
@@ -1100,7 +1099,6 @@ ut.iadsdk.apple.com
 uts-api.itunes.apple.com
 uts-api-siri.itunes.apple.com
 uts-preview.itunes.apple.com
-valid.apple.com
 videos.apple.com
 vocabulary.itunes.apple.com
 vpp-app.itunes.apple.com


### PR DESCRIPTION
This PR fixes issue #27 by removing some domains that are needed for Apple devices to work properly and as Apple advices for "enterprise networks".