### PR TITLE
Issue 31 🐛 GoDaddy's OCSP shouldn't be blocked to be able obtain the revocation status of an X.509 digital certificate

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -581,7 +581,6 @@ news.apple.com
 np.itunes.apple.com
 ns.itunes.apple.com
 ns.itunes-apple.com.akadns.net
-ocsp.godaddy.com.akadns.net
 opensource.apple.com
 origin.guzzoni-apple.com.akadns.net
 origin.seed-siri-apple.com.akadns.net


### PR DESCRIPTION
This PR fixes issue #31 